### PR TITLE
context: add basic support for context

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -151,11 +151,7 @@ func (j *Jeff) Set(ctx context.Context, w http.ResponseWriter, key []byte, meta 
 	if len(meta) > 1 {
 		panic("meta must not be longer than 1")
 	}
-	secure, err := genRandomString(24) // 192 bits
-	if err != nil {
-		// Critical System error
-		panic(err)
-	}
+	secure := genRandomString(24) // 192 bits
 	c := &http.Cookie{
 		Secure:   !j.insecure,
 		HttpOnly: true,
@@ -218,22 +214,22 @@ func (j *Jeff) defaults() {
 // string.  It will return an error if the system's secure random number
 // generator fails to function correctly, in which case the caller should not
 // continue.
-func genRandomString(n int) (string, error) {
-	b, err := genRandomBytes(n)
-	return encode(b), err
+func genRandomString(n int) string {
+	b := genRandomBytes(n)
+	return encode(b)
 }
 
 // genRandomBytes returns securely generated random bytes.  It will return an
 // error if the system's secure random number generator fails to function
 // correctly, in which case the caller should not continue.
-func genRandomBytes(n int) ([]byte, error) {
+func genRandomBytes(n int) []byte {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
 	// Note that err != nil when we fail to read len(b) bytes.
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return b, nil
+	return b
 }
 
 func encode(b []byte) string {

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -288,10 +288,3 @@ func TestSessCookie(t *testing.T) {
 	cookie := cookies[0]
 	assert.True(t, cookie.Expires.IsZero(), "cookie expiration not set (session cookie)")
 }
-
-// This doesn't work :-(
-// func SetTimes(t time.Time) {
-// 	jeff.SetTime(func() time.Time { return t })
-// 	memory.SetTime(func() time.Time { return t })
-// 	redis_store.SetTime(func() time.Time { return t })
-// }


### PR DESCRIPTION
This doesn't add full support.  Doing so requires cooperation from the
libraries.  However, this does solve the case where a request is
cancelled, we don't block and return control to the caller.  The
consequence is that we're leaking a goroutine for the remainder of the
open request to memcache/redis (which shouldn't be long)

Both libraries expose the ability to set timeouts on connections.  It
might be worthwhile to see how to integrate them more seamlessly:

https://godoc.org/github.com/bradfitz/gomemcache/memcache#ConnectTimeoutError
https://godoc.org/github.com/gomodule/redigo/redis#DoWithTimeout