### PR TITLE
sessions: implictly clear session cookie

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -91,8 +91,7 @@ func (s *server) loginHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) logoutHandler(w http.ResponseWriter, r *http.Request) {
-	sess := jeff.ActiveSession(r.Context())
-	s.jeff.Clear(r.Context(), sess.Key)
+	s.jeff.Clear(r.Context(), w)
 	http.Redirect(w, r, "/", 302)
 }
 

--- a/sessions.go
+++ b/sessions.go
@@ -124,8 +124,8 @@ func (j *Jeff) Public(wrap http.Handler) http.Handler {
 // PublicFunc wraps the given handler, adding the Session object (if there's an
 // active session) to the request context before passing control to the next
 // handler.
-func (j *Jeff) PublicFunc(wrap http.HandlerFunc) http.Handler {
-	return j.wrap(wrap, wrap)
+func (j *Jeff) PublicFunc(wrap http.HandlerFunc) http.HandlerFunc {
+	return j.wrap(wrap, wrap).ServeHTTP
 }
 
 // Wrap wraps the given handler, authenticating this route and calling the
@@ -136,8 +136,8 @@ func (j *Jeff) Wrap(wrap http.Handler) http.Handler {
 
 // WrapFunc wraps the given handler, authenticating this route and calling the
 // redirect handler if session is invalid.
-func (j *Jeff) WrapFunc(wrap http.HandlerFunc) http.Handler {
-	return j.wrap(j.redir, wrap)
+func (j *Jeff) WrapFunc(wrap http.HandlerFunc) http.HandlerFunc {
+	return j.wrap(j.redir, wrap).ServeHTTP
 }
 
 func (j *Jeff) wrap(redir, wrap http.Handler) http.Handler {

--- a/sessions.go
+++ b/sessions.go
@@ -209,7 +209,25 @@ func (j *Jeff) Set(ctx context.Context, w http.ResponseWriter, key []byte, meta 
 }
 
 // Clear the session for the given key.
-func (j *Jeff) Clear(ctx context.Context, key []byte) error {
+func (j *Jeff) Clear(ctx context.Context, w http.ResponseWriter) {
+	s := ActiveSession(ctx)
+	c := &http.Cookie{
+		Secure:   !j.insecure,
+		HttpOnly: true,
+		Name:     j.cookieName,
+		Value:    "deleted",
+		Path:     j.path,
+		Domain:   j.domain,
+		Expires:  time.Time{},
+	}
+	http.SetCookie(w, c)
+	if len(s.Key) > 0 {
+		j.clear(ctx, s.Key)
+	}
+}
+
+// Delete the session for the given key.
+func (j *Jeff) Delete(ctx context.Context, key []byte) error {
 	return j.clear(ctx, key)
 }
 


### PR DESCRIPTION
Breaking API change:

Clear now implicitly clears the active session on the given context and
also clears the cookie by setting the expiry date to the zero value of
`time.Time`.

`Delete` was added to replace the previous `Clear` behavior.