### PR TITLE
Expire token cookie in addition to deleting the value

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -227,7 +227,9 @@ func (j *Jeff) Clear(ctx context.Context, w http.ResponseWriter) error {
 		Value:    "deleted",
 		Path:     j.path,
 		Domain:   j.domain,
-		Expires:  time.Unix(0, 0),
+		// Negative MaxAge actually sets 'Max-Age: 0'
+		// https://pkg.go.dev/net/http#Cookie
+		MaxAge: -1,
 	})
 	if len(s.Key) > 0 {
 		// TODO: a bit worried about corrupt (empty) tokens.

--- a/sessions.go
+++ b/sessions.go
@@ -220,16 +220,15 @@ func (j *Jeff) Set(ctx context.Context, w http.ResponseWriter, key []byte, meta 
 // Clear the session in the context for the given key.
 func (j *Jeff) Clear(ctx context.Context, w http.ResponseWriter) error {
 	s := ActiveSession(ctx)
-	c := &http.Cookie{
+	http.SetCookie(w, &http.Cookie{
 		Secure:   !j.insecure,
 		HttpOnly: true,
 		Name:     j.cookieName,
 		Value:    "deleted",
 		Path:     j.path,
 		Domain:   j.domain,
-		Expires:  time.Time{},
-	}
-	http.SetCookie(w, c)
+		Expires:  time.Unix(0, 0),
+	})
 	if len(s.Key) > 0 {
 		// TODO: a bit worried about corrupt (empty) tokens.
 		return j.clear(ctx, s.Key, s.Token)


### PR DESCRIPTION
After the server invalidates the session token, it should expire it to indicate to the client that the client should be deleted. Otherwise, the client keeps sending an invalid value of 'deleted' as the session token, which just creates noise.