### PR TITLE
Remove error message when using Insecure option

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -98,7 +97,6 @@ func Expires(dur time.Duration) func(*Jeff) {
 // Insecure unsets the Secure flag for the cookie.  This is for development
 // only.  Doing this in production is an error.
 func Insecure(j *Jeff) {
-	log.Println("ERROR: sessions configured insecurely. for development only")
 	j.insecure = true
 }
 


### PR DESCRIPTION
I understand the purpose of the Secure attribute on cookies, but I think the jeff library is making too many assumptions about requiring them. The error message is inappropriate in several situations:

- During development, the log message creates unnecessary output on every reload of the server code.
- There are instances where an implementer might have a legitimate need to exclude the Secure cookie attribute (e.g., a trusted network, an HTTP connection that's routed through a secure SSH tunnel).

To remove the Secure attribute, jeff already requires the client to specify the Insecure option. If the user is explicitly choosing that option, the library should accept that choice rather than generating error messages about it.